### PR TITLE
Prefer Japanese Posters

### DIFF
--- a/src/commands/showtimes.js
+++ b/src/commands/showtimes.js
@@ -83,7 +83,10 @@ class Showtimes extends Aquarius.Command {
       .then(res => res.json())
       .then(res => {
         const id = res.data[0].id;
-        return fetch(`${TVDB_URL}/series/${id}/images/query?keyType=poster`, { headers });
+        return fetch(
+          `${TVDB_URL}/series/${id}/images/query?keyType=poster`,
+          { headers: Object.assign({}, headers, { 'Accept-Language': 'ja' }) }
+          );
       })
       .then(res => res.json())
       .then(res => {

--- a/src/commands/showtimes.js
+++ b/src/commands/showtimes.js
@@ -83,12 +83,26 @@ class Showtimes extends Aquarius.Command {
       .then(res => res.json())
       .then(res => {
         const id = res.data[0].id;
-        return fetch(
+        let requests = [];
+        requests.push(fetch(
           `${TVDB_URL}/series/${id}/images/query?keyType=poster`,
           { headers: Object.assign({}, headers, { 'Accept-Language': 'ja' }) }
-          );
+          ));
+        requests.push(fetch(
+          `${TVDB_URL}/series/${id}/images/query?keyType=poster`,
+          { headers }
+          ));
+        return Promise.all(requests);
       })
-      .then(res => res.json())
+      .then(responses => Promise.all(responses.map(res => res.json())))
+      .then(res => {
+        // no Japanese posters, fallback to English
+        if ('Error' in res[0]) {
+          return res[1];
+        }
+        // default to Japanese posters
+        return res[0];
+      })
       .then(res => {
         const results = res.data.sort((a, b) => a.ratingsInfo.average < b.ratingsInfo.average);
         const url = `https://thetvdb.com/banners/${results[0].fileName}`;


### PR DESCRIPTION
Would be nicer with object spread, but that would require a newer version of Node.

Assigning the header for all requests requires the show name to be specified in Japanese, so it is only applied when requesting for posters.

Unfortunately the TVDB api ignores everything after the first `Accept-Language`, so multiple API requests are required.

A fallback to English posters is applied for cases like Uma Musume which do not have any Japanese posters.