### PR TITLE
Set zeroFirstCell to false on beginner minesweeper

### DIFF
--- a/packages/aquarius/src/bot/commands/minesweeper.js
+++ b/packages/aquarius/src/bot/commands/minesweeper.js
@@ -28,16 +28,19 @@ const DIFFICULTIES = {
     rows: 4,
     columns: 4,
     mines: 2,
+    zeroFirstCell: false,
   },
   intermediate: {
     rows: 8,
     columns: 8,
     mines: 10,
+    zeroFirstCell: true,
   },
   expert: {
     rows: 15,
     columns: 8,
     mines: 25,
+    zeroFirstCell: true,
   },
 };
 
@@ -49,12 +52,13 @@ export default async ({ aquarius, analytics }) => {
       log('Generating game');
 
       const difficulty = groups.difficulty || 'beginner';
-      const { rows, columns, mines } = DIFFICULTIES[difficulty];
+      const { rows, columns, mines, zeroFirstCell } = DIFFICULTIES[difficulty];
 
       const minesweeper = new Minesweeper({
         rows,
         columns,
         mines,
+        zeroFirstCell,
         revealFirstCell: true,
       });
 


### PR DESCRIPTION
The beginner board is too easy if at least half of the board is already revealed. Set `zeroFirstCell` to `false` on the beginner difficulty and to `true` on the others.