### PR TITLE
Update embeds.js (fix online guild members)

### DIFF
--- a/packages/aquarius/src/core/helpers/embeds.js
+++ b/packages/aquarius/src/core/helpers/embeds.js
@@ -23,7 +23,7 @@ export async function guildEmbed(guild, ...fields) {
   const date = getStandardDate(guild.createdAt);
 
   const activeMembers = guild.members.cache.filter(
-    (member) => member.presence.status === 'online'
+    (member) => member.presence.status !== 'offline'
   );
 
   const channelTypes = {


### PR DESCRIPTION
This should fix online guild members only counting members with the status online and now also include members with dnd or idle set. (Issue #822)
I hope that works, should though right?