### PR TITLE
Reminders: Use discord's native timestamp syntax

### DIFF
--- a/packages/aquarius/src/bot/commands/reminders.js
+++ b/packages/aquarius/src/bot/commands/reminders.js
@@ -33,22 +33,10 @@ export const info = {
 
 /** @type {import('../../typedefs').Command} */
 export default async ({ aquarius, analytics }) => {
-  const formatDate = async (date, user) => {
-    const service = await aquarius.services.getLink(user, 'Timezone');
-    const tz = service?.values?.Timezone;
-
-    try {
-      return date.toLocaleString('en-US', {
-        timeZone: tz ?? 'UTC',
-        timeZoneName: 'short',
-      });
-    } catch (error) {
-      return date.toLocaleString('en-US', {
-        timeZone: 'UTC',
-        timeZoneName: 'short',
-      });
-    }
-  };
+  const formatDate = async (date) => {
+    const timestamp = Math.round(date.getTime() / 1000);
+    return `<t:${timestamp}> (<t:${timestamp}:R>)`;
+};
 
   let reminderTimeout = null;
   const refreshTimeout = async () => {
@@ -159,7 +147,7 @@ export default async ({ aquarius, analytics }) => {
             },
           });
 
-          const time = await formatDate(date, message.author);
+          const time = await formatDate(date);
           message.channel.send(`Alright, I'll remind you on ${time}`);
 
           refreshTimeout();
@@ -202,7 +190,7 @@ export default async ({ aquarius, analytics }) => {
               message.guild.channels.resolve(reminder.channelId) ??
               '#deleted-channel';
 
-            const time = await formatDate(reminder.time, message.author);
+            const time = await formatDate(reminder.time);
             return `${index + 1}. On ${time} in ${channel}, "${
               reminder.message
             }"`;
@@ -260,7 +248,7 @@ export default async ({ aquarius, analytics }) => {
 
           refreshTimeout();
 
-          const time = await formatDate(reminder.time, message.author);
+          const time = await formatDate(reminder.time);
           message.channel.send(
             `Alright, I will no longer remind you on ${time} to "${reminder.message}"`
           );


### PR DESCRIPTION
I don't see a reason *not* to use these. Automatically translate to user's local time, plus we can even give an up-to-date counter to *when* it will happen.

This might mean we can remove newly extraneous code elsewhere, but I'm not sure what, if any, that would be. Storing the user's timezone is still probably useful for something (though looks like we don't currently use it to, say, define the timezone for setting new reminders?).